### PR TITLE
Handle multiprocessing fallback and fix worker spawn pickling

### DIFF
--- a/prlearn/base/trainer.py
+++ b/prlearn/base/trainer.py
@@ -186,8 +186,8 @@ class Trainer:
                 break
         logger.debug(f"Worker handler for worker {worker_index} done")
 
+    @staticmethod
     def _run_worker(
-        self,
         idx: int,
         env: Environment,
         agent: Agent,
@@ -301,7 +301,7 @@ class Trainer:
         logger.debug("Starting processes")
         for i in range(self.n_workers):
             process = mp_context.Process(
-                target=self._run_worker,
+                target=Trainer._run_worker,
                 args=(
                     i,
                     self.env,

--- a/prlearn/utils/message_utils.py
+++ b/prlearn/utils/message_utils.py
@@ -1,8 +1,7 @@
-import os
 import queue
 from typing import Any
 
-import multiprocess as mp
+from prlearn.utils.multiproc_lib import mp
 
 
 def queue_receive(q: mp.Queue, timeout=None):


### PR DESCRIPTION
## Summary
- use the shared multiprocess/multiprocessing helper inside message utilities to avoid optional dependency import failures
- make the worker process entry static so spawning processes no longer pickles trainer locks

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ee130312083338150240934d4cb63)