### PR TITLE
Add CI workflow for pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: default
+            install_target: .
+            extra: false
+          - name: multiprocess
+            install_target: .[multiprocess]
+            extra: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install ${{ matrix.install_target }}
+          pip install pytest
+          if [ "${{ matrix.extra }}" = "true" ]; then
+            pip install multiprocess
+          fi
+
+      - name: Run tests
+        run: pytest tests/


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs on pull requests and pushes to main
- set up Python 3.11, install dependencies, and test both default and multiprocess optional extra configurations
- run the test suite with pytest