### PR TITLE
Optimize experience handoff between workers

### DIFF
--- a/prlearn/base/experience.py
+++ b/prlearn/base/experience.py
@@ -5,6 +5,20 @@ from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar
 T = TypeVar("T", bound="Experience")
 
 
+EXPERIENCE_FIELDS = [
+    "observations",
+    "actions",
+    "rewards",
+    "next_observations",
+    "terminated",
+    "truncated",
+    "info",
+    "agent_versions",
+    "worker_ids",
+    "episodes",
+]
+
+
 @dataclass
 class Experience:
     """
@@ -120,18 +134,7 @@ class Experience:
         Args:
             exp (Experience): Another experience object to concatenate.
         """
-        for attr in [
-            "observations",
-            "actions",
-            "rewards",
-            "next_observations",
-            "terminated",
-            "truncated",
-            "info",
-            "agent_versions",
-            "worker_ids",
-            "episodes",
-        ]:
+        for attr in EXPERIENCE_FIELDS:
             getattr(self, attr).extend(getattr(exp, attr))
 
     def copy(self) -> "Experience":
@@ -141,23 +144,7 @@ class Experience:
         Returns:
             Experience: A copy of this experience buffer.
         """
-        return Experience(
-            *[
-                getattr(self, attr).copy()
-                for attr in [
-                    "observations",
-                    "actions",
-                    "rewards",
-                    "next_observations",
-                    "terminated",
-                    "truncated",
-                    "info",
-                    "agent_versions",
-                    "worker_ids",
-                    "episodes",
-                ]
-            ]
-        )
+        return Experience(*[getattr(self, attr).copy() for attr in EXPERIENCE_FIELDS])
 
     def get(self, columns: Optional[List[str]] = None) -> Tuple:
         """
@@ -204,22 +191,35 @@ class Experience:
         if size is None:
             size = len(self)
         return Experience(
-            *[
-                getattr(self, attr)[-size:]
-                for attr in [
-                    "observations",
-                    "actions",
-                    "rewards",
-                    "next_observations",
-                    "terminated",
-                    "truncated",
-                    "info",
-                    "agent_versions",
-                    "worker_ids",
-                    "episodes",
-                ]
-            ]
+            *[getattr(self, attr)[-size:] for attr in EXPERIENCE_FIELDS]
         )
+
+    def pop_experience_batch(self, size: Optional[int] = None) -> "Experience":
+        """
+        Remove and return the last `size` steps as a new Experience object.
+
+        Args:
+            size (int, optional): Number of steps to include. If None or greater
+                than the available steps, removes and returns all.
+        Returns:
+            Experience: New experience object with the removed steps.
+        """
+        current_len = len(self)
+        if not current_len:
+            return Experience()
+
+        if size is None or size >= current_len:
+            batch = self.copy()
+            self.clear()
+            return batch
+
+        slice_idx = slice(-size, None)
+        batch_data = []
+        for attr in EXPERIENCE_FIELDS:
+            src = getattr(self, attr)
+            batch_data.append(src[slice_idx])
+            del src[slice_idx]
+        return Experience(*batch_data)
 
     def to_dict(self) -> dict:
         """


### PR DESCRIPTION
## Summary
- add reusable field list and a pop-based batch extractor to Experience to avoid redundant slicing and clearing
- shift worker send path to pop batches and accumulate returned experience separately to reduce queue pressure while preserving results